### PR TITLE
⚒️ fix: 개인 정보 동의 스크린 리팩토링 완료

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -51,7 +51,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_pdfview: 25f53dd6097661e6395b17de506e6060585946bd
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/bindings/root_binding.dart
+++ b/lib/bindings/root_binding.dart
@@ -5,6 +5,7 @@ import 'package:bommeong/viewModels/like/like_viewmodel.dart';
 import 'package:bommeong/viewModels/login/login_viewmodel.dart';
 import 'package:bommeong/viewModels/message/message_viewmodel.dart';
 import 'package:bommeong/viewModels/my/my_viewmodel.dart';
+import 'package:bommeong/viewModels/privacy/privacy_viewmodel.dart';
 import 'package:get/get.dart';
 import 'package:bommeong/viewModels/home/home_viewmodel.dart';
 import 'package:bommeong/viewModels/root/root_viewmodel.dart';
@@ -22,7 +23,7 @@ class RootBinding extends Bindings {
     Get.lazyPut(() => DogInfoViewModel(),fenix: true);
     Get.lazyPut(() => PostController(),fenix: true);
     Get.put(LoginViewModel());
-
+    Get.put(PrivacyViewModel());
     //DogInfoViewModel를 최대한 빨리 생성하기위한 코드
 
     Get.lazyPut(() => MessageViewModel());

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -12,7 +12,7 @@ import 'userpreferences_service.dart';
 class GetChatList {
   Future<List<ChatList>> fetchItems(int pageKey) async {
 
-    String? mainpageAPI = '${dotenv.env['BOM_API']}/chat/${UserPreferences.getMemberId()}'; //일단 이걸로
+    String? mainpageAPI = '${dotenv.env['BOM_API']}/chat/${UserPreferences.getMemberId()}'; // 일단 이걸로
 
     final response = await http.get(
       Uri.parse(mainpageAPI),

--- a/lib/utilities/font_system.dart
+++ b/lib/utilities/font_system.dart
@@ -18,6 +18,13 @@ abstract class FontSystem {
     color: Colors.black,
   );
 
+  static const TextStyle KR22B = TextStyle(
+    fontSize: 22,
+    fontWeight: FontWeight.w700,
+    fontFamily: 'Pretendard',
+    color: Colors.black,
+  );
+
   static const TextStyle KR42M = TextStyle(
     fontSize: 42,
     fontWeight: FontWeight.w500,

--- a/lib/views/home/home_screen.dart
+++ b/lib/views/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:bommeong/viewModels/like/like_viewmodel.dart';
 import 'package:bommeong/views/home/doginfo_screen.dart';
 import 'package:bommeong/views/home/post_screen.dart';
 import 'package:bommeong/views/login/login_screen.dart';
+import 'package:bommeong/views/privacy/privacy_consent_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:bommeong/viewModels/home/home_viewmodel.dart';
@@ -107,8 +108,8 @@ class _Header extends StatelessWidget {
                   ],
                 ),
               )
-
             ),
+
             Container(
               padding: const EdgeInsets.only(right: 16),
               child: Image.asset(
@@ -117,6 +118,27 @@ class _Header extends StatelessWidget {
                 height: 32,
               ),
             ),
+
+            // ToDO: 인터뷰 스크린 이동용으로 잠시 해놓은 것. 나중에 지우기(InkWell)
+            InkWell(
+              onTap: () {
+                Get.to(() => PrivacyConsentScreen());
+              },
+              child: Container(
+                width: Get.width * 0.10,
+                padding: EdgeInsets.symmetric(vertical: 5, horizontal: 5),
+                // 패딩 조정으로 버튼 크기 조정
+                decoration: BoxDecoration(
+                  color: Color(0xFFA273FF), // 배경색 설정
+                  borderRadius: BorderRadius.circular(8), // 모서리 둥글기 반경 설정
+                ),
+                child: Text(
+                  '테스트', // 버튼 텍스트
+                  style: FontSystem.KR10B.copyWith(color: Colors.black), // 텍스트 스타일
+                  textAlign: TextAlign.center, // 텍스트 정렬
+                ),
+              ),
+            )
 
           ],
         ),
@@ -278,7 +300,6 @@ class _DogComponent extends StatelessWidget {
     );
   }
 }
-
 
 class _BottomButton extends StatelessWidget {
   const _BottomButton({super.key});

--- a/lib/views/privacy/adoption_screen.dart
+++ b/lib/views/privacy/adoption_screen.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+import 'package:bommeong/viewModels/home/doginfo_viewmodel.dart';
+import 'package:bommeong/viewModels/message/message_viewmodel.dart';
+import 'package:bommeong/viewModels/root/root_viewmodel.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:bommeong/views/base/base_screen.dart';
+import 'package:bommeong/utilities/font_system.dart';
+import 'package:get/get.dart';
+import '../../viewModels/privacy/privacy_viewmodel.dart';
+import 'hand_sign_screen.dart';
+
+class AdoptionScreen extends BaseScreen<PrivacyViewModel> {
+  const AdoptionScreen({super.key});
+
+  @override
+  Widget buildBody(BuildContext context) {
+    final PrivacyViewModel viewModel = Get.put(PrivacyViewModel());
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(10.0), // 모든 방향에 대해 20의 패딩 적용
+        child: Column(
+          children: [
+            Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(20.0), // Header 위젯에 패딩 적용
+                  child: _Header(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0), // Question 위젯에 패딩 적용
+                  child: _Question(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool get wrapWithOuterSafeArea => true;
+  @override
+  bool get wrapWithInnerSafeArea => true;
+}
+
+class _Header extends StatelessWidget {
+  const _Header({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+                child: RichText(
+                  text: TextSpan(
+                    style: FontSystem.KR20EB.copyWith(color: Color(0xFF000000)), // 기본 스타일
+                    children: <TextSpan>[
+                      TextSpan(text: '개인 정보 동의'),
+                    ],
+                  ),
+                )
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Question extends StatelessWidget {
+  const _Question({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start, // 추가된 부분
+      children: [
+        RichText(
+          text: TextSpan(
+            style: FontSystem.KR20B.copyWith(color: Colors.black),
+            children: <TextSpan>[
+              TextSpan(text: '입양을 결심해주셔서\n감사합니다\n\n더 안전한 입양을 위해\n아래 내용을\n'),
+              TextSpan(
+                text: '확인',
+                style: TextStyle(color: Color(0xFFCCB7F7)),
+              ),
+              TextSpan(text: '해주세요'),
+            ],
+          ),
+        ),
+        // 여기에 다른 위젯들을 추가할 수 있습니다.
+      ],
+    );
+  }
+}

--- a/lib/views/privacy/adoption_screen.dart
+++ b/lib/views/privacy/adoption_screen.dart
@@ -1,14 +1,12 @@
 import 'dart:io';
-import 'package:bommeong/viewModels/home/doginfo_viewmodel.dart';
-import 'package:bommeong/viewModels/message/message_viewmodel.dart';
-import 'package:bommeong/viewModels/root/root_viewmodel.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:bommeong/views/base/base_screen.dart';
-import 'package:bommeong/utilities/font_system.dart';
 import 'package:get/get.dart';
+import 'package:bommeong/utilities/font_system.dart';
+import 'package:bommeong/views/base/base_screen.dart';
 import '../../viewModels/privacy/privacy_viewmodel.dart';
-import 'hand_sign_screen.dart';
+
+final QuestionNum = 0.obs;
 
 class AdoptionScreen extends BaseScreen<PrivacyViewModel> {
   const AdoptionScreen({super.key});
@@ -17,27 +15,44 @@ class AdoptionScreen extends BaseScreen<PrivacyViewModel> {
   Widget buildBody(BuildContext context) {
     final PrivacyViewModel viewModel = Get.put(PrivacyViewModel());
 
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(10.0), // 모든 방향에 대해 20의 패딩 적용
-        child: Column(
+    return Obx(() => Stack(
+      children: [
+        Column(
           children: [
-            Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(20.0), // Header 위젯에 패딩 적용
-                  child: _Header(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(20.0), // Question 위젯에 패딩 적용
-                  child: _Question(),
-                ),
-              ],
+            Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: _Header(),
             ),
+            if (QuestionNum.value == 0)
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: _Question(),
+              ),
+            if (QuestionNum.value == 1)
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: _FirstQuestion(),
+              ),
+            if (QuestionNum.value == 2)
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: _SecondQuestion(),
+              ),
           ],
         ),
-      ),
-    );
+        Positioned(
+          bottom: 30, // 아래 패딩 30
+          left: 0,
+          right: 0,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 30.0), // 좌우 패딩 30
+            child: QuestionNum.value == 0 ? _StartButton() :
+                    QuestionNum.value == 1 ? _FirstButton() :
+                     QuestionNum.value == 2 ? _SecondShortAnswer() : _FirstButton(),
+          ),
+        ),
+      ],
+    ));
   }
 
   @override
@@ -54,17 +69,17 @@ class _Header extends StatelessWidget {
     return Column(
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Container(
-                child: RichText(
-                  text: TextSpan(
-                    style: FontSystem.KR20EB.copyWith(color: Color(0xFF000000)), // 기본 스타일
-                    children: <TextSpan>[
-                      TextSpan(text: '개인 정보 동의'),
-                    ],
-                  ),
-                )
+              child: RichText(
+                text: TextSpan(
+                  style: FontSystem.KR20EB.copyWith(color: Color(0xFF000000)),
+                  children: <TextSpan>[
+                    TextSpan(text: '입양 신청서'),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
@@ -72,29 +87,260 @@ class _Header extends StatelessWidget {
     );
   }
 }
-
+// 시작
 class _Question extends StatelessWidget {
   const _Question({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start, // 추가된 부분
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        RichText(
-          text: TextSpan(
-            style: FontSystem.KR20B.copyWith(color: Colors.black),
-            children: <TextSpan>[
-              TextSpan(text: '입양을 결심해주셔서\n감사합니다\n\n더 안전한 입양을 위해\n아래 내용을\n'),
-              TextSpan(
-                text: '확인',
-                style: TextStyle(color: Color(0xFFCCB7F7)),
-              ),
-              TextSpan(text: '해주세요'),
-            ],
+        Container(
+          padding: EdgeInsets.all(20),
+          width: MediaQuery.of(context).size.width - 40,
+          child: RichText(
+            text: TextSpan(
+              style: FontSystem.KR22B.copyWith(color: Colors.black),
+              children: <TextSpan>[
+                TextSpan(text: '몇가지 '),
+                TextSpan(
+                  text: '간단한 질문',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: '을\n드리겠습니다\n\n'),
+                TextSpan(
+                  text: '입양 심사',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: '에 사용되는\n자료이므로\n'),
+                TextSpan(
+                  text: '성실히 답변',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: ' 부탁드립니다'),
+              ],
+            ),
           ),
         ),
-        // 여기에 다른 위젯들을 추가할 수 있습니다.
+      ],
+    );
+  }
+}
+// 1
+class _FirstQuestion extends StatelessWidget {
+  const _FirstQuestion({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: EdgeInsets.all(20),
+          width: MediaQuery.of(context).size.width - 40,
+          child: RichText(
+            text: TextSpan(
+              style: FontSystem.KR22B.copyWith(color: Colors.black),
+              children: <TextSpan>[
+                TextSpan(text: 'Q.\n'),
+                TextSpan(
+                  text: '반려 동물',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: '을\n키우신 '),
+                TextSpan(
+                  text: '경험',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: '이 있습니까?'),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+// 2
+class _SecondQuestion extends StatelessWidget {
+  const _SecondQuestion({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: EdgeInsets.all(20),
+          width: MediaQuery.of(context).size.width - 40,
+          child: RichText(
+            text: TextSpan(
+              style: FontSystem.KR22B.copyWith(color: Colors.black),
+              children: <TextSpan>[
+                TextSpan(text: 'Q.\n'),
+                TextSpan(
+                  text: '어떤 종류',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: '의 동물을\n'),
+                TextSpan(
+                  text: '얼마나',
+                  style: FontSystem.KR22B.copyWith(color: Color(0xFFA273FF)),
+                ),
+                TextSpan(text: ' 키웠나요?'),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+
+// 0 -> 1(시작)
+class _StartButton extends StatelessWidget {
+  const _StartButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: MediaQuery.of(context).size.width - 40,
+          height: 50,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Color(0xFFA273FF),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            onPressed: () {
+              QuestionNum.value = 1;
+            },
+            child: Text(
+              '확인했습니다',
+              style: FontSystem.KR16B.copyWith(color: Colors.white),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+// 1 -> 2(예) or 1 -> 3(아니오)
+class _FirstButton extends StatelessWidget {
+  const _FirstButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: MediaQuery.of(context).size.width - 40,
+          height: 50,
+          child: OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              backgroundColor: Colors.white,
+              side: BorderSide(color: Color(0xFFA273FF)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            onPressed: () {
+              QuestionNum.value = 2;
+            },
+            child: Text(
+              '네, 있습니다.',
+              style: FontSystem.KR16B.copyWith(
+                color: Colors.black,
+              ),
+            ),
+          ),
+        ),
+        SizedBox(height: 30),
+        Container(
+          width: MediaQuery.of(context).size.width - 40,
+          height: 50,
+          child: OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              backgroundColor: Colors.white,
+              side: BorderSide(color: Color(0xFFA273FF)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            onPressed: () {
+              QuestionNum.value = 3;
+            },
+            child: Text(
+              '아니오, 없습니다.',
+              style: FontSystem.KR16B.copyWith(
+                color: Colors.black,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+// 2(주관식)
+class _SecondShortAnswer extends StatelessWidget {
+  const _SecondShortAnswer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController _controller = TextEditingController();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          height: 450,
+          decoration: BoxDecoration(
+            color: Colors.white, // 배경을 흰색으로 변경
+            borderRadius: BorderRadius.circular(10), // 모서리 곡률 10
+            border: Border.all(
+              color: Color(0xFFCCB7F7), // 가장자리에 스트로크 추가
+              width: 1, // 스트로크 너비 설정
+            ),
+          ),
+          padding: EdgeInsets.symmetric(horizontal: 15),
+          child: TextField(
+            controller: _controller, // 사용자 입력을 추적하는 컨트롤러 추가
+            maxLines: null, // 무제한 줄 입력 가능
+            decoration: InputDecoration(
+              border: InputBorder.none,
+              hintText: "클릭하여 작성해주세요.",
+            ),
+          ),
+        ),
+        SizedBox(height: 30),
+        Container(
+          width: MediaQuery.of(context).size.width - 40,
+          height: 50,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Color(0xFFA273FF),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            onPressed: () {
+              // viewModel.thirdResponse.value = _controller.text;
+              QuestionNum.value = 4;
+            },
+            child: Text(
+              '작성 완료',
+              style: FontSystem.KR16B.copyWith(color: Colors.white),
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/lib/views/privacy/hand_sign_screen.dart
+++ b/lib/views/privacy/hand_sign_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:hand_signature/signature.dart';
 import 'package:path_provider/path_provider.dart';
-import '../../../utilities/font_system.dart';
+import '../../utilities/font_system.dart';
 
 class SignaturePage extends StatefulWidget {
   @override

--- a/lib/views/privacy/privacy_consent_screen.dart
+++ b/lib/views/privacy/privacy_consent_screen.dart
@@ -1,12 +1,15 @@
-import 'package:bommeong/viewModels/home/doginfo_viewmodel.dart';
-import 'package:bommeong/viewModels/message/message_viewmodel.dart';
-import 'package:bommeong/viewModels/root/root_viewmodel.dart';
+import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:bommeong/views/base/base_screen.dart';
 import 'package:bommeong/utilities/font_system.dart';
 import 'package:get/get.dart';
 import '../../viewModels/privacy/privacy_viewmodel.dart';
+import 'adoption_screen.dart';
+import 'hand_sign_screen.dart';
+
+final isAgreed_1 = false.obs;
+final signatureData = Rx<File?>(null);
 
 class PrivacyConsentScreen extends BaseScreen<PrivacyViewModel> {
   const PrivacyConsentScreen({super.key});
@@ -16,21 +19,42 @@ class PrivacyConsentScreen extends BaseScreen<PrivacyViewModel> {
     final PrivacyViewModel viewModel = Get.put(PrivacyViewModel());
 
     return SingleChildScrollView(
-      child: Column(
-        children: [
-          const SizedBox(height: 16),
-          Stack(
-            children: [
-              _Header(),
-
-
-            ],
-          ),
-
-        ],
+      child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Column(
+          children: [
+            Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Header(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Question(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Body(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Checkbox(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Signature(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: _Completebutton(),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
-
   }
 
   @override
@@ -46,38 +70,209 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Container(
-          //정렬
-          alignment: Alignment.centerLeft,
-          padding: const EdgeInsets.only(left: 30),
-          child: Text("처음 오셨네요!",
-            style: FontSystem.KR12B.copyWith(color: Color(0xFF979797)),),
-        ),
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.center, // 중앙으로 정렬
           children: [
             Container(
-                padding: const EdgeInsets.only(left: 30),
                 child: RichText(
                   text: TextSpan(
                     style: FontSystem.KR20EB.copyWith(color: Color(0xFF000000)), // 기본 스타일
                     children: <TextSpan>[
-                      TextSpan(text: '만나서 반가워요, '),
-                      TextSpan(text: '님!'),
+                      TextSpan(text: '개인 정보 동의'),
                     ],
                   ),
                 )
             ),
-            Container(
-              padding: const EdgeInsets.only(right: 16),
-              child: Image.asset(
-                "assets/images/home/profile.png",
-                width: 32,
-                height: 32,
-              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Question extends StatelessWidget {
+  const _Question({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽으로 정렬
+      children: [
+        Container(
+          padding: EdgeInsets.all(20), // 텍스트에 패딩 추가
+          width: MediaQuery.of(context).size.width - 40,
+          child: RichText(
+            text: TextSpan(
+              style: FontSystem.KR20B.copyWith(color: Colors.black),
+              children: <TextSpan>[
+                TextSpan(text: '입양을 결심해주셔서\n감사합니다\n\n더 안전한 입양을 위해\n아래 내용을\n'),
+                TextSpan(
+                  text: '확인',
+                  style: TextStyle(color: Color(0xFFCCB7F7)),
+                ),
+                TextSpan(text: '해주세요'),
+              ],
+            ),
+          ),
+        ),
+        // 여기에 다른 위젯들을 추가할 수 있습니다.
+      ],
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start, // 추가된 부분
+      children: [
+        Container(
+          padding: EdgeInsets.all(20), // 텍스트에 패딩 추가
+          width: MediaQuery.of(context).size.width - 40,
+          decoration: BoxDecoration(
+            color: Colors.white, // 배경을 흰색으로 변경
+            borderRadius: BorderRadius.circular(10), // 모서리 곡률 10
+            border: Border.all(
+              color: Color(0xFFCCB7F7), // 가장자리에 스트로크 추가
+              width: 1, // 스트로크 너비 설정
+            ),
+          ),
+          child: RichText(
+            text: TextSpan(
+              children: [
+                WidgetSpan(
+                  child: Icon(Icons.check, size: 15.0, color: Color(0xFFCCB7F7)), // 체크 표시 아이콘 추가
+                ),
+                TextSpan(
+                  text: '  [필수] 개인 정보 동의서 본문 확인', style: FontSystem.KR15M.copyWith(color: Colors.black),
+                ),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(height: 30),
+        Text(
+          '❶ 수집 · 조회 이용 목적 유기견입양신청 및 유기견입양심사와 관련하여 개인정보를 수집·조회 이용\n\n'
+              '❷ 수집 · 조회 · 이용 항목 : 생년월일, 성명, 주소, 전화번호, 유기견과의 대화내역, 유기견입양신청서\n\n'
+              '❸ 개인정보 보유 및 이용기간 신청일로부터 5년 <보유기간 경과시 파기>\n\n'
+              '❹ 동의하지 않을 권리 및 미동의시 불이익 귀하는 본건 유기견입양 및 입양심사와 관련하여 귀하의 개인정보 수집 · 조회 · 이용에 대하여 거부할 권리가 있으며, 동의를 거부할 경우(입양 심사 결과 등)의 불이익을 받을 수 있습니다.\n\n'
+              '위 개인정보의 수집 조회 이용과 같은 내용으로 개인정보를 처리하고 있습니다.\n\n'
+              '귀하로부터 취득한 개인정보는 개인정보보호법 제 15조, 제17조, 제18조, 제23조 및 제24조에서 정하는 바에 따라 처리 목적 이외에는 사용되지 않으며 변경 시에는 사전 동의를 구할 것입니다.',
+          style: FontSystem.KR16M.copyWith(color: Colors.black),
+        ),
+      ],
+    );
+  }
+}
+
+class _Checkbox extends StatelessWidget {
+  _Checkbox({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Text(
+              '위 항목에 모두 동의합니다',
+              style: FontSystem.KR18B.copyWith(color: Colors.black),
+            ),
+            InkWell(
+              onTap: () {
+                isAgreed_1.value = !isAgreed_1.value;
+              },
+              child: Obx(() => Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: isAgreed_1.value ? Color(0xFFCCB7F7) : Colors.white,
+                  border: Border.all(color: Color(0xFFCCB7F7), width: 1),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(5.0),
+                  child: isAgreed_1.value
+                      ? Icon(Icons.check, size: 20.0, color: Colors.white)
+                      : Icon(Icons.check, size: 20.0, color: Color(0xFFCCB7F7)),
+                ),
+              )),
             ),
           ],
         ),
+      ],
+    );
+  }
+}
+
+class _Signature extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        InkWell(
+          // Todo: 서명 다시하면 해당 서명으로 업데이터 해야됨
+          onTap: () async {
+            // 서명 페이지로 이동하고 File로 서명 결과를 받아옴
+            final File? result = await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => SignaturePage()),
+            );
+            if (result != null) {
+              signatureData.value = result;
+              // viewModel.updateUploadFile(result); // viewModel 사용 시
+            }
+          },
+          child: Obx(() => Container(
+            width: MediaQuery.of(context).size.width - 60, // 좌우 여백 30을 고려한 너비
+            height: 150, // 서명 컨테이너의 높이
+            decoration: BoxDecoration(
+              color: Colors.white, // 회색 배경
+              borderRadius: BorderRadius.circular(10), // 둥근 모서리
+              border: Border.all(
+                color: Color(0xFFCCB7F7), // 가장자리에 스트로크 추가
+                width: 1, // 스트로크 너비 설정
+              ),
+            ),
+            child: Center(
+              child: signatureData.value != null
+                  ? Image.file(signatureData.value!) // File 객체를 직접 사용
+                  : Text('클릭해서 서명하세요', style: FontSystem.KR18B.copyWith(color: Colors.black)), // 서명 전 문구
+            ),
+          )),
+        ),
+      ],
+    );
+  }
+}
+
+class _Completebutton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Obx(() => Container(
+          width: MediaQuery.of(context).size.width - 40, // 핸드폰 가로 너비에서 40(양쪽 20씩)을 뺀 값
+          height: 50,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: isAgreed_1.value && signatureData.value != null ? Color(0xFFA273FF): Color(0xFFCBB9F0),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10), // 곡률을 10으로 설정
+              ),
+            ),
+            onPressed: isAgreed_1.value && signatureData.value != null
+                ? () {
+              Get.to(() => AdoptionScreen());
+            }
+                : null, // 조건이 충족되지 않으면 버튼 비활성화
+            child: Text('입양 신청서 작성하기',
+              style: FontSystem.KR16B.copyWith(color: Colors.white),
+            ),
+          ),
+        )),
       ],
     );
   }

--- a/lib/views/privacy/privacy_consent_screen.dart
+++ b/lib/views/privacy/privacy_consent_screen.dart
@@ -26,7 +26,7 @@ class PrivacyConsentScreen extends BaseScreen<PrivacyViewModel> {
             Column(
               children: [
                 Padding(
-                  padding: const EdgeInsets.all(20.0),
+                  padding: const EdgeInsets.all(10.0),
                   child: _Header(),
                 ),
                 Padding(
@@ -251,14 +251,14 @@ class _Signature extends StatelessWidget {
 class _Completebutton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Obx(() => Column(
       children: [
-        Obx(() => Container(
+        Container(
           width: MediaQuery.of(context).size.width - 40, // 핸드폰 가로 너비에서 40(양쪽 20씩)을 뺀 값
           height: 50,
           child: ElevatedButton(
             style: ElevatedButton.styleFrom(
-              backgroundColor: isAgreed_1.value && signatureData.value != null ? Color(0xFFA273FF): Color(0xFFCBB9F0),
+              backgroundColor: isAgreed_1.value && signatureData.value != null ? Color(0xFFA273FF) : Color(0xFFCBB9F0),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(10), // 곡률을 10으로 설정
               ),
@@ -268,12 +268,13 @@ class _Completebutton extends StatelessWidget {
               Get.to(() => AdoptionScreen());
             }
                 : null, // 조건이 충족되지 않으면 버튼 비활성화
-            child: Text('입양 신청서 작성하기',
+            child: Text(
+              '입양 신청서 작성하기',
               style: FontSystem.KR16B.copyWith(color: Colors.white),
             ),
           ),
-        )),
+        ),
       ],
-    );
+    ));
   }
 }

--- a/lib/views/privacy/privacy_consent_screen.dart
+++ b/lib/views/privacy/privacy_consent_screen.dart
@@ -1,0 +1,84 @@
+import 'package:bommeong/viewModels/home/doginfo_viewmodel.dart';
+import 'package:bommeong/viewModels/message/message_viewmodel.dart';
+import 'package:bommeong/viewModels/root/root_viewmodel.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:bommeong/views/base/base_screen.dart';
+import 'package:bommeong/utilities/font_system.dart';
+import 'package:get/get.dart';
+import '../../viewModels/privacy/privacy_viewmodel.dart';
+
+class PrivacyConsentScreen extends BaseScreen<PrivacyViewModel> {
+  const PrivacyConsentScreen({super.key});
+
+  @override
+  Widget buildBody(BuildContext context) {
+    final PrivacyViewModel viewModel = Get.put(PrivacyViewModel());
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          const SizedBox(height: 16),
+          Stack(
+            children: [
+              _Header(),
+
+
+            ],
+          ),
+
+        ],
+      ),
+    );
+
+  }
+
+  @override
+  bool get wrapWithOuterSafeArea => true;
+  @override
+  bool get wrapWithInnerSafeArea => true;
+}
+
+class _Header extends StatelessWidget {
+  const _Header({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          //정렬
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(left: 30),
+          child: Text("처음 오셨네요!",
+            style: FontSystem.KR12B.copyWith(color: Color(0xFF979797)),),
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+                padding: const EdgeInsets.only(left: 30),
+                child: RichText(
+                  text: TextSpan(
+                    style: FontSystem.KR20EB.copyWith(color: Color(0xFF000000)), // 기본 스타일
+                    children: <TextSpan>[
+                      TextSpan(text: '만나서 반가워요, '),
+                      TextSpan(text: '님!'),
+                    ],
+                  ),
+                )
+            ),
+            Container(
+              padding: const EdgeInsets.only(right: 16),
+              child: Image.asset(
+                "assets/images/home/profile.png",
+                width: 32,
+                height: 32,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/privacy/widget/privacy_consent_screen.dart
+++ b/lib/views/privacy/widget/privacy_consent_screen.dart
@@ -1,1 +1,0 @@
-// TODO Implement this library.

--- a/lib/views/root/custom_bottom_navigation_bar.dart
+++ b/lib/views/root/custom_bottom_navigation_bar.dart
@@ -87,8 +87,6 @@ class CustomBottomNavigationBar extends BaseWidget<RootViewModel> {
         )
             : Container(),
       );
-
-
 }
 
 

--- a/lib/views/root/root_screen.dart
+++ b/lib/views/root/root_screen.dart
@@ -15,6 +15,8 @@ import 'package:bommeong/views/root/custom_bottom_navigation_bar.dart';
 import '../../viewModels/root/root_viewmodel.dart';
 import 'package:bommeong/views/widget/privacy/privacy_consent_screen.dart';
 
+import '../privacy/privacy_consent_screen.dart';
+
 class RootScreen extends BaseScreen<RootViewModel> {
   const RootScreen({super.key});
 
@@ -34,6 +36,7 @@ class RootScreen extends BaseScreen<RootViewModel> {
           OnboardingScreen(0), //6
           OnboardingScreen(2), //7
           LoginScreen(), //8
+          PrivacyConsentScreen(), //9
         ],
       ),
     );

--- a/lib/views/widget/privacy/privacy_consent_screen.dart
+++ b/lib/views/widget/privacy/privacy_consent_screen.dart
@@ -8,7 +8,6 @@ import '../../../utilities/font_system.dart';
 import 'hand_sign.dart';
 import '../adoption/Question2.dart';
 
-
 class OnboardingScreen extends StatefulWidget {
   final int currentPage;
   OnboardingScreen(this.currentPage);

--- a/lib/views/widget/privacy/privacy_consent_screen.dart
+++ b/lib/views/widget/privacy/privacy_consent_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:hand_signature/signature.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import '../../../utilities/font_system.dart';
-import 'hand_sign.dart';
+import '../../privacy/hand_sign_screen.dart';
 import '../adoption/Question2.dart';
 
 class OnboardingScreen extends StatefulWidget {


### PR DESCRIPTION
## 🔥 Related Issues

-   close #67 

## ⛅️ 작업 내용

-   [x]  개인 정보 동의 스크린 구조 바꾸기(전부 리팩토링)
-   [x]  Privacy 폴더 하나 만들어서 해당 폴더에 스크린 정리하기

## 👀 스크린샷 / GIF / 링크

<img width="815" alt="스크린샷 2024-05-27 오전 4 39 46" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_9_FE/assets/59414536/afb553a4-ec03-4c50-a0af-5960e4b7ed15">

